### PR TITLE
fix: Do not lock account on failed dispute.

### DIFF
--- a/src/model/account.rs
+++ b/src/model/account.rs
@@ -76,12 +76,11 @@ impl Account {
                     .open_dispute()
                     .map_err(|e| anyhow!("{e} for {:?}", transaction.tx))?;
 
-                let result = self.balance.hold(amount);
-                if result.is_err() {
-                    self.lock();
-                }
+                self.balance.hold(amount)
 
-                result
+                // FIXME: I think we should lock the account here if hold().is_err(); as this looks like a
+                // typical case of fraud, but I don't want to break the spec without discussing it
+                // with whomever is going to consume this.
             }
             Type::Resolve => {
                 let deposit = self.get_deposit(transaction.tx)?;

--- a/src/model/test.rs
+++ b/src/model/test.rs
@@ -11,7 +11,7 @@ use super::{
 // Amount tests
 #[test]
 fn negative_amount_allow_only_nonnegative_values() {
-    Amount::try_from(dec!(-1)).expect_err("Only non-negative values allowed");
+    Amount::try_from(dec!(-1)).expect_err("only non-negative values allowed");
 }
 
 // Balance tests
@@ -213,7 +213,7 @@ fn positive_account_edge_case_open_dispute_after_previous_one_resolved() {
     ];
 
     txns.map(|txn| {
-        account.apply(txn).expect("All transactions should succeed");
+        account.apply(txn).expect("all transactions should succeed");
     });
     assert_eq!(account.balance.available(), Amount::ZERO);
     assert_eq!(account.balance.held(), Amount::ZERO);
@@ -290,7 +290,7 @@ fn negative_account_dispute_missing_deposit() {
     txns.map(|txn| {
         account
             .apply(txn)
-            .expect_err("Can't process dispute on a deposit that doesn't exist");
+            .expect_err("can't process dispute on a deposit that doesn't exist");
     });
 }
 
@@ -333,8 +333,8 @@ fn negative_account_dispute_insufficient_funds() {
         .apply(txns[2])
         .expect_err("dispute should fail due to insufficient funds");
 
-    // We lock the account defensively
-    assert!(account.locked);
+    // The spec does not say we should lock the account
+    assert!(!account.locked);
 }
 
 #[test]
@@ -368,11 +368,11 @@ fn negative_account_edge_case_open_dispute_after_previous_one_chargedback() {
     txns.as_slice()[0..3].iter().for_each(|txn| {
         account
             .apply(*txn)
-            .expect("All transactions should succeed");
+            .expect("all transactions should succeed");
     });
     account
         .apply(txns[3])
-        .expect_err("Account should be locked, so the dispute should fail");
+        .expect_err("account should be locked, so the dispute should fail");
     assert_eq!(account.balance.available(), Amount::ZERO);
     assert_eq!(account.balance.held(), Amount::ZERO);
     assert!(account.locked);


### PR DESCRIPTION
- When dispute can't be processed due to insufficient funds, it seems like a good idea to lock the account, as this is the typical fraudulent scenario. But doing so risks breaking the expectations of whatever is going to consume our output.
- It seems safer to just ignore the transaction and acknowledge the posibility of improving, rather than boldly changing the spec.
- Docs already reflected this behaviour, but the code had not been updated.